### PR TITLE
Create parent dir tree when necessary when creating device specs

### DIFF
--- a/src/main/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommand.java
@@ -168,8 +168,8 @@ public abstract class GetDeviceSpecCommand {
         Files.deleteIfExists(getOutputPath());
       }
 
-      if (Files.notExists(outputFile.getParent())) {
-        Files.createDirectories(outputFile.getParent());
+      if (Files.notExists(getOutputPath().getParent())) {
+        Files.createDirectories(getOutputPath().getParent());
       }
 
       Files.write(outputFile, JsonFormat.printer().print(deviceSpec).getBytes(UTF_8));

--- a/src/main/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommand.java
@@ -167,6 +167,11 @@ public abstract class GetDeviceSpecCommand {
       if (getOverwriteOutput()) {
         Files.deleteIfExists(getOutputPath());
       }
+
+      if (Files.notExists(outputFile.getParent())) {
+        Files.createDirectories(outputFile.getParent());
+      }
+
       Files.write(outputFile, JsonFormat.printer().print(deviceSpec).getBytes(UTF_8));
     } catch (IOException e) {
       throw new UncheckedIOException(

--- a/src/test/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommandTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/commands/GetDeviceSpecCommandTest.java
@@ -264,6 +264,21 @@ public class GetDeviceSpecCommandTest {
   }
 
   @Test
+  public void nonExistentParentDirectory_works() {
+    DeviceSpec deviceSpec = mergeSpecs(sdkVersion(21), density(480), abis("x86"), locales("en-US"));
+
+    Path outputPath = tmp.getRoot().toPath().resolve("non-existent-parent-directory").resolve("device.json");
+    GetDeviceSpecCommand command =
+            GetDeviceSpecCommand.builder()
+                    .setAdbPath(adbPath)
+                    .setAdbServer(fakeServerOneDevice(deviceSpec))
+                    .setOutputPath(outputPath)
+                    .build();
+
+    assertThat(command.execute()).isEqualTo(deviceSpec);
+  }
+
+  @Test
   public void oneDevice_badSdkVersion_throws() throws Exception {
     DeviceSpec deviceSpec =
         mergeSpecs(sdkVersion(1), density(360), abis("x86_64", "x86"), locales("en-US"));


### PR DESCRIPTION
Prevent crashing when trying to write the device spec under a directory which is actually not created. Now we create the entire directories tree.

Currently at `v0.8.0`, this is crashing as described in #46 . This fixes #46 .

- [x] Tests