### PR TITLE
Extension to get-size command

### DIFF
--- a/src/main/java/com/android/tools/build/bundletool/commands/GetSizeCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/GetSizeCommand.java
@@ -91,9 +91,9 @@ public abstract class GetSizeCommand implements GetSizeRequest {
 
   /** Sub Sub commands supported on {@link GetSizeCommand}*/
   public enum GetSizeSubSubCommand {
-    MB("mb"),
-    KB("kb"),
-    BYTES("bytes");
+    MB("MB"),
+    KB("KB"),
+    BYTES("BYTES");
 
     static final ImmutableMap<String, GetSizeSubSubCommand> STRING_TO_SUB_SUBCOMMAND =
             Arrays.stream(GetSizeSubSubCommand.values())
@@ -183,7 +183,7 @@ public abstract class GetSizeCommand implements GetSizeRequest {
     /** Sets the sub-command of the get-size command, e.g. total. */
     public abstract Builder setGetSizeSubCommand(GetSizeSubcommand getSizeSubcommand);
 
-    /** Sets the sub-sub-command of the get-size command, e.g. kb,mb,bytes */
+    /** Sets the sub-sub-command of the get-size command, e.g. BYTES, KB, MB */
     public abstract Builder setGetSizeSubSubCommand(GetSizeSubSubCommand getSizeSubSubCommand);
 
     public abstract GetSizeCommand build();

--- a/src/main/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregator.java
+++ b/src/main/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregator.java
@@ -61,12 +61,12 @@ public class VariantTotalSizeAggregator {
 
   private static final Joiner COMMA_JOINER = Joiner.on(',');
 
-  private final ImmutableMap<String, Long> sizeByApkPaths;
+  private final ImmutableMap<String, Double> sizeByApkPaths;
   private final Variant variant;
   private final GetSizeRequest getSizeRequest;
 
   public VariantTotalSizeAggregator(
-      ImmutableMap<String, Long> sizeByApkPaths, Variant variant, GetSizeRequest getSizeRequest) {
+      ImmutableMap<String, Double> sizeByApkPaths, Variant variant, GetSizeRequest getSizeRequest) {
     this.sizeByApkPaths = sizeByApkPaths;
     this.variant = variant;
     this.getSizeRequest = getSizeRequest;
@@ -118,13 +118,13 @@ public class VariantTotalSizeAggregator {
             getSizeRequest.getDeviceSpec());
 
     // Variants of standalone APKs have only one APK each.
-    long compressedSize =
+    double compressedSize =
         sizeByApkPaths.get(
             Iterables.getOnlyElement(
                     Iterables.getOnlyElement(variant.getApkSetList()).getApkDescriptionList())
                 .getPath());
 
-    ImmutableMap<SizeConfiguration, Long> sizeConfigurationMap =
+    ImmutableMap<SizeConfiguration, Double> sizeConfigurationMap =
         ImmutableMap.of(sizeConfiguration, compressedSize);
     return ConfigurationSizes.create(sizeConfigurationMap, sizeConfigurationMap);
   }
@@ -194,8 +194,8 @@ public class VariantTotalSizeAggregator {
       ImmutableSet<AbiTargeting> abiTargetingOptions,
       ImmutableSet<LanguageTargeting> languageTargetingOptions,
       ImmutableSet<ScreenDensityTargeting> screenDensityTargetingOptions) {
-    Map<SizeConfiguration, Long> minSizeByConfiguration = new HashMap<>();
-    Map<SizeConfiguration, Long> maxSizeByConfiguration = new HashMap<>();
+    Map<SizeConfiguration, Double> minSizeByConfiguration = new HashMap<>();
+    Map<SizeConfiguration, Double> maxSizeByConfiguration = new HashMap<>();
 
     SdkVersionTargeting sdkVersionTargeting = variant.getTargeting().getSdkVersionTargeting();
     for (AbiTargeting abiTargeting : abiTargetingOptions) {
@@ -208,7 +208,7 @@ public class VariantTotalSizeAggregator {
                       sdkVersionTargeting, abiTargeting, screenDensityTargeting, languageTargeting),
                   getSizeRequest.getDeviceSpec());
 
-          long compressedSize =
+          double compressedSize =
               getCompressedSize(
                   new ApkMatcher(
                           getDeviceSpec(
@@ -301,7 +301,7 @@ public class VariantTotalSizeAggregator {
   }
 
   /** Gets the total compressed sizes represented by the APK paths. */
-  private long getCompressedSize(ImmutableList<ZipPath> apkPaths) {
-    return apkPaths.stream().mapToLong(apkPath -> sizeByApkPaths.get(apkPath.toString())).sum();
+  private double getCompressedSize(ImmutableList<ZipPath> apkPaths) {
+    return apkPaths.stream().mapToDouble(apkPath -> sizeByApkPaths.get(apkPath.toString())).sum();
   }
 }

--- a/src/main/java/com/android/tools/build/bundletool/flags/ParsedFlags.java
+++ b/src/main/java/com/android/tools/build/bundletool/flags/ParsedFlags.java
@@ -77,6 +77,16 @@ public final class ParsedFlags {
     return getSubCommand(1);
   }
 
+  /**
+   * Returns the third command provided on the command line if provided.
+   *
+   * <p>e.g. for "bundletool get-size total bytes", the command is 'get-size', the sub-command
+   * is 'total' and the sub-sub-command is 'bytes'.
+   */
+  public Optional<String> getSubSubCommand() {
+    return getSubCommand(2);
+  }
+
   private Optional<String> getSubCommand(int index) {
     return index < commands.size() ? Optional.of(commands.get(index)) : Optional.empty();
   }

--- a/src/main/java/com/android/tools/build/bundletool/model/ConfigurationSizes.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/ConfigurationSizes.java
@@ -25,13 +25,13 @@ import com.google.errorprone.annotations.Immutable;
 @AutoValue.CopyAnnotations
 public abstract class ConfigurationSizes {
 
-  public abstract ImmutableMap<SizeConfiguration, Long> getMinSizeConfigurationMap();
+  public abstract ImmutableMap<SizeConfiguration, Double> getMinSizeConfigurationMap();
 
-  public abstract ImmutableMap<SizeConfiguration, Long> getMaxSizeConfigurationMap();
+  public abstract ImmutableMap<SizeConfiguration, Double> getMaxSizeConfigurationMap();
 
   public static ConfigurationSizes create(
-      ImmutableMap<SizeConfiguration, Long> minSizeConfigurationMap,
-      ImmutableMap<SizeConfiguration, Long> maxSizeConfigurationMap) {
+      ImmutableMap<SizeConfiguration, Double> minSizeConfigurationMap,
+      ImmutableMap<SizeConfiguration, Double> maxSizeConfigurationMap) {
     return new AutoValue_ConfigurationSizes(minSizeConfigurationMap, maxSizeConfigurationMap);
   }
 }

--- a/src/main/java/com/android/tools/build/bundletool/model/utils/ApkSizeUtils.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/utils/ApkSizeUtils.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.android.bundle.Commands.ApkDescription;
 import com.android.bundle.Commands.Variant;
+import com.android.tools.build.bundletool.commands.GetSizeCommand.GetSizeSubSubCommand;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -38,29 +39,37 @@ public class ApkSizeUtils {
    * Returns a map of APK Paths inside the APK Set with the sizes, for all APKs in variants
    * provided.
    */
-  public static ImmutableMap<String, Long> getCompressedSizeByApkPaths(
-      ImmutableList<Variant> variants, Path apksArchive) {
+  public static ImmutableMap<String, Double> getCompressedSizeByApkPaths(
+          ImmutableList<Variant> variants, Path apksArchive, GetSizeSubSubCommand sizeSubSubCommand) {
     ImmutableList<String> apkPaths =
-        variants.stream()
-            .flatMap(variant -> variant.getApkSetList().stream())
-            .flatMap(apkSet -> apkSet.getApkDescriptionList().stream())
-            .map(ApkDescription::getPath)
-            .distinct()
-            .collect(toImmutableList());
-    ImmutableMap.Builder<String, Long> sizeByApkPath = ImmutableMap.builder();
+            variants.stream()
+                    .flatMap(variant -> variant.getApkSetList().stream())
+                    .flatMap(apkSet -> apkSet.getApkDescriptionList().stream())
+                    .map(ApkDescription::getPath)
+                    .distinct()
+                    .collect(toImmutableList());
+    ImmutableMap.Builder<String, Double> sizeByApkPath = ImmutableMap.builder();
     try (ZipFile apksZip = new ZipFile(apksArchive.toFile())) {
       for (String apkPath : apkPaths) {
         ZipEntry entry = checkNotNull(apksZip.getEntry(apkPath));
         // It's possible that the compressed size is larger than the uncompressed one, but the
         // smallest APK is the one that is actually served.
         try (InputStream inputStream = apksZip.getInputStream(entry)) {
-          long size = Math.min(entry.getSize(), calculateGzipCompressedSize(inputStream));
-          sizeByApkPath.put(apkPath, size);
+          double size = Math.min(entry.getSize(), calculateGzipCompressedSize(inputStream));
+          switch (sizeSubSubCommand){
+            case MB:
+              size = size/1024;
+            case KB:
+              size = size/1024;
+              break;
+
+          }
+          sizeByApkPath.put(apkPath, Double.parseDouble(String.format("%.2f",size)));
         }
       }
     } catch (IOException e) {
       throw new UncheckedIOException(
-          String.format("Error while processing the APK Set archive '%s'.", apksArchive), e);
+              String.format("Error while processing the APK Set archive '%s'.", apksArchive), e);
     }
     return sizeByApkPath.build();
   }

--- a/src/main/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtils.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtils.java
@@ -72,8 +72,8 @@ public final class GetSizeCsvUtils {
   private static ImmutableList<String> getSizeTotalCsvRow(
       ImmutableSet<Dimension> dimensions,
       SizeConfiguration sizeConfiguration,
-      long minSize,
-      long maxSize) {
+      double minSize,
+      double maxSize) {
     ImmutableMap<Dimension, Supplier<Optional<String>>> dimensionToTextMap =
         ImmutableMap.of(
             Dimension.ABI, sizeConfiguration::getAbi,

--- a/src/test/java/com/android/tools/build/bundletool/commands/GetSizeCommandTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/commands/GetSizeCommandTest.java
@@ -288,7 +288,7 @@ public final class GetSizeCommandTest {
 
     GetSizeCommand fromFlags =
         GetSizeCommand.fromFlags(
-            new FlagParser().parse("get-size", "total", "kb", "--apks=" + apksArchiveFile));
+            new FlagParser().parse("get-size", "total", "KB", "--apks=" + apksArchiveFile));
 
     GetSizeCommand fromBuilderApi =
         GetSizeCommand.builder()

--- a/src/test/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregatorTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregatorTest.java
@@ -77,7 +77,8 @@ public class VariantTotalSizeAggregatorTest {
   private final GetSizeCommand.Builder getSizeCommand =
       GetSizeCommand.builder()
           .setApksArchivePath(ZipPath.create("dummy.apks"))
-          .setGetSizeSubCommand(GetSizeSubcommand.TOTAL);
+          .setGetSizeSubCommand(GetSizeSubcommand.TOTAL)
+          .setGetSizeSubSubCommand(GetSizeCommand.GetSizeSubSubCommand.BYTES);
 
   @Test
   public void splitVariant_singleModule_SingleTargeting() {
@@ -90,12 +91,12 @@ public class VariantTotalSizeAggregatorTest {
                     ApkTargeting.getDefaultInstance(), ZipPath.create("base-master.apk"))));
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("base-master.apk", 10L), lVariant, getSizeCommand.build())
+            ImmutableMap.of("base-master.apk", 10D), lVariant, getSizeCommand.build())
             .getSize();
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 10L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 10D);
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 10L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 10D);
   }
 
   @Test
@@ -117,15 +118,15 @@ public class VariantTotalSizeAggregatorTest {
                     /* isMasterSplit= */ false)));
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("base-master.apk", 10L, "base-x86.apk", 4L, "base-x86_64.apk", 6L),
-                lVariant,
-                getSizeCommand.build())
+            ImmutableMap.of("base-master.apk", 10D, "base-x86.apk", 4D, "base-x86_64.apk", 6D),
+            lVariant,
+            getSizeCommand.build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 16L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 16D);
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 14L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 14D);
   }
 
   @Test
@@ -160,39 +161,39 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("base-armeabi.apk", 4L)
-                    .put("base-arm64_v8a.apk", 6L)
-                    .put("base-xhdpi.apk", 2L)
-                    .put("base-xxhdpi.apk", 3L)
-                    .put("base-en.apk", 1L)
-                    .build(),
-                lVariant,
-                getSizeCommand.setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY)).build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("base-armeabi.apk", 4D)
+                .put("base-arm64_v8a.apk", 6D)
+                .put("base-xhdpi.apk", 2D)
+                .put("base-xxhdpi.apk", 3D)
+                .put("base-en.apk", 1D)
+                .build(),
+            lVariant,
+            getSizeCommand.setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY)).build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
         .containsExactly(
             SizeConfiguration.builder().setAbi("armeabi").setScreenDensity("XHDPI").build(),
-            17L,
+            17D,
             SizeConfiguration.builder().setAbi("armeabi").setScreenDensity("XXHDPI").build(),
-            18L,
+            18D,
             SizeConfiguration.builder().setAbi("arm64-v8a").setScreenDensity("XHDPI").build(),
-            19L,
+            19D,
             SizeConfiguration.builder().setAbi("arm64-v8a").setScreenDensity("XXHDPI").build(),
-            20L);
+            20D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .containsExactly(
             SizeConfiguration.builder().setAbi("armeabi").setScreenDensity("XHDPI").build(),
-            17L,
+            17D,
             SizeConfiguration.builder().setAbi("armeabi").setScreenDensity("XXHDPI").build(),
-            18L,
+            18D,
             SizeConfiguration.builder().setAbi("arm64-v8a").setScreenDensity("XHDPI").build(),
-            19L,
+            19D,
             SizeConfiguration.builder().setAbi("arm64-v8a").setScreenDensity("XXHDPI").build(),
-            20L);
+            20D);
   }
 
   @Test
@@ -223,25 +224,25 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("base-en.apk", 1L)
-                    .put("base-fr.apk", 2L)
-                    .put("base-mdpi.apk", 6L)
-                    .put("base-ldpi.apk", 3L)
-                    .build(),
-                lVariant,
-                getSizeCommand
-                    .setDimensions(ImmutableSet.of(LANGUAGE))
-                    .setDeviceSpec(mergeSpecs(locales("en")))
-                    .build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("base-en.apk", 1D)
+                .put("base-fr.apk", 2D)
+                .put("base-mdpi.apk", 6D)
+                .put("base-ldpi.apk", 3D)
+                .build(),
+            lVariant,
+            getSizeCommand
+                .setDimensions(ImmutableSet.of(LANGUAGE))
+                .setDeviceSpec(mergeSpecs(locales("en")))
+                .build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.builder().setLocale("en").build(), 17L);
+        .containsExactly(SizeConfiguration.builder().setLocale("en").build(), 17D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.builder().setLocale("en").build(), 14L);
+        .containsExactly(SizeConfiguration.builder().setLocale("en").build(), 14D);
   }
 
   @Test
@@ -280,35 +281,35 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("base-jp.apk", 1L)
-                    .put("base-en-US.apk", 2L)
-                    .put("base-xhdpi.apk", 6L)
-                    .put("base-xxhdpi.apk", 3L)
-                    .put("base-x86.apk", 4L)
-                    .put("base-x86_64.apk", 5L)
-                    .build(),
-                lVariant,
-                getSizeCommand
-                    .setDimensions(ImmutableSet.of(SCREEN_DENSITY, SDK))
-                    .setDeviceSpec(mergeSpecs(locales("jp"), abis("x86")))
-                    .build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("base-jp.apk", 1D)
+                .put("base-en-US.apk", 2D)
+                .put("base-xhdpi.apk", 6D)
+                .put("base-xxhdpi.apk", 3D)
+                .put("base-x86.apk", 4D)
+                .put("base-x86_64.apk", 5D)
+                .build(),
+            lVariant,
+            getSizeCommand
+                .setDimensions(ImmutableSet.of(SCREEN_DENSITY, SDK))
+                .setDeviceSpec(mergeSpecs(locales("jp"), abis("x86")))
+                .build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
         .containsExactly(
             SizeConfiguration.builder().setSdkVersion("21-").setScreenDensity("XHDPI").build(),
-            21L,
+            21D,
             SizeConfiguration.builder().setSdkVersion("21-").setScreenDensity("XXHDPI").build(),
-            18L);
+            18D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .containsExactly(
             SizeConfiguration.builder().setSdkVersion("21-").setScreenDensity("XHDPI").build(),
-            21L,
+            21D,
             SizeConfiguration.builder().setSdkVersion("21-").setScreenDensity("XXHDPI").build(),
-            18L);
+            18D);
   }
 
   @Test
@@ -347,25 +348,25 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("base-fr.apk", 1L)
-                    .put("base-en-GB.apk", 2L)
-                    .put("base-xhdpi.apk", 6L)
-                    .put("base-xxhdpi.apk", 3L)
-                    .put("base-mips.apk", 4L)
-                    .put("base-mips64.apk", 5L)
-                    .build(),
-                lVariant,
-                getSizeCommand
-                    .setDimensions(ImmutableSet.of(SCREEN_DENSITY, SDK, LANGUAGE, ABI))
-                    .setDeviceSpec(
-                        mergeSpecs(
-                            locales("fr", "jp"),
-                            abis("x86", "mips"),
-                            density(XHDPI),
-                            sdkVersion(21)))
-                    .build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("base-fr.apk", 1D)
+                .put("base-en-GB.apk", 2D)
+                .put("base-xhdpi.apk", 6D)
+                .put("base-xxhdpi.apk", 3D)
+                .put("base-mips.apk", 4D)
+                .put("base-mips64.apk", 5D)
+                .build(),
+            lVariant,
+            getSizeCommand
+                .setDimensions(ImmutableSet.of(SCREEN_DENSITY, SDK, LANGUAGE, ABI))
+                .setDeviceSpec(
+                    mergeSpecs(
+                        locales("fr", "jp"),
+                        abis("x86", "mips"),
+                        density(XHDPI),
+                        sdkVersion(21)))
+                .build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
@@ -376,7 +377,7 @@ public class VariantTotalSizeAggregatorTest {
                 .setLocale("fr,jp")
                 .setAbi("x86,mips")
                 .build(),
-            21L);
+            21D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .containsExactly(
@@ -386,7 +387,7 @@ public class VariantTotalSizeAggregatorTest {
                 .setLocale("fr,jp")
                 .setAbi("x86,mips")
                 .build(),
-            21L);
+            21D);
   }
 
   @Test
@@ -405,9 +406,9 @@ public class VariantTotalSizeAggregatorTest {
 
     VariantTotalSizeAggregator variantTotalSizeAggregator =
         new VariantTotalSizeAggregator(
-            ImmutableMap.<String, Long>builder()
-                .put("apkL.apk", 10L)
-                .put("apkL-x86.apk", 6L)
+            ImmutableMap.<String, Double>builder()
+                .put("apkL.apk", 10D)
+                .put("apkL-x86.apk", 6D)
                 .build(),
             lVariant,
             getSizeCommand
@@ -450,22 +451,22 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("feature-master.apk", 15L)
-                    .put("feature1-master.apk", 6L)
-                    .put("feature2-master.apk", 4L)
-                    .build(),
-                lVariant,
-                getSizeCommand.setModules(ImmutableSet.of("base", "feature1")).build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("feature-master.apk", 15D)
+                .put("feature1-master.apk", 6D)
+                .put("feature2-master.apk", 4D)
+                .build(),
+            lVariant,
+            getSizeCommand.setModules(ImmutableSet.of("base", "feature1")).build())
             .getSize();
 
     // base, feature1, feature2 (install-time) modules are selected.
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 20L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 20D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 20L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 20D);
   }
 
   @Test
@@ -489,20 +490,20 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("feature-master.apk", 15L)
-                    .put("feature1-master.apk", 6L)
-                    .build(),
-                lVariant,
-                getSizeCommand.setInstant(true).build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("feature-master.apk", 15D)
+                .put("feature1-master.apk", 6D)
+                .build(),
+            lVariant,
+            getSizeCommand.setInstant(true).build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 31L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 31D);
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 31L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 31D);
   }
 
   @Test
@@ -545,25 +546,25 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.<String, Long>builder()
-                    .put("base-master.apk", 10L)
-                    .put("base-mips.apk", 3L)
-                    .put("base-x86.apk", 4L)
-                    .put("base-en.apk", 1L)
-                    .put("base-fr.apk", 2L)
-                    .put("feature-master.apk", 15L)
-                    .put("feature-xhdpi.apk", 6L)
-                    .put("feature-xxhdpi.apk", 5L)
-                    .build(),
-                lVariant,
-                getSizeCommand.setDeviceSpec(mergeSpecs(density(XHDPI), abis("mips"))).build())
+            ImmutableMap.<String, Double>builder()
+                .put("base-master.apk", 10D)
+                .put("base-mips.apk", 3D)
+                .put("base-x86.apk", 4D)
+                .put("base-en.apk", 1D)
+                .put("base-fr.apk", 2D)
+                .put("feature-master.apk", 15D)
+                .put("feature-xhdpi.apk", 6D)
+                .put("feature-xxhdpi.apk", 5D)
+                .build(),
+            lVariant,
+            getSizeCommand.setDeviceSpec(mergeSpecs(density(XHDPI), abis("mips"))).build())
             .getSize();
 
     assertThat(configurationSizes.getMaxSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 36L); // 10+3+2+15+6
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 36D); // 10+3+2+15+6
 
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 35L); // 10+3+1+15+6
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 35D); // 10+3+1+15+6
   }
 
   @Test
@@ -579,12 +580,12 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("sample.apk", 10L), variant, getSizeCommand.build())
+            ImmutableMap.of("sample.apk", 10D), variant, getSizeCommand.build())
             .getSize();
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .isEqualTo(configurationSizes.getMaxSizeConfigurationMap());
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 10L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 10D);
   }
 
   @Test
@@ -599,9 +600,9 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("sample.apk", 10L),
-                variant,
-                getSizeCommand.setModules(ImmutableSet.of("base")).build())
+            ImmutableMap.of("sample.apk", 10D),
+            variant,
+            getSizeCommand.setModules(ImmutableSet.of("base")).build())
             .getSize();
     assertThat(configurationSizes.getMaxSizeConfigurationMap()).isEmpty();
     assertThat(configurationSizes.getMinSizeConfigurationMap()).isEmpty();
@@ -621,11 +622,11 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("sample.apk", 20L),
-                variant,
-                getSizeCommand
-                    .setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY, LANGUAGE, SDK))
-                    .build())
+            ImmutableMap.of("sample.apk", 20D),
+            variant,
+            getSizeCommand
+                .setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY, LANGUAGE, SDK))
+                .build())
             .getSize();
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .isEqualTo(configurationSizes.getMaxSizeConfigurationMap());
@@ -637,7 +638,7 @@ public class VariantTotalSizeAggregatorTest {
                 .setSdkVersion("1-20")
                 .setLocale("")
                 .build(),
-            20L);
+            20D);
   }
 
   @Test
@@ -654,14 +655,14 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("sample.apk", 15L),
-                variant,
-                getSizeCommand.setDeviceSpec(mergeSpecs(locales("jp"), abis("mips"))).build())
+            ImmutableMap.of("sample.apk", 15D),
+            variant,
+            getSizeCommand.setDeviceSpec(mergeSpecs(locales("jp"), abis("mips"))).build())
             .getSize();
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .isEqualTo(configurationSizes.getMaxSizeConfigurationMap());
     assertThat(configurationSizes.getMinSizeConfigurationMap())
-        .containsExactly(SizeConfiguration.getDefaultInstance(), 15L);
+        .containsExactly(SizeConfiguration.getDefaultInstance(), 15D);
   }
 
   @Test
@@ -678,17 +679,17 @@ public class VariantTotalSizeAggregatorTest {
 
     ConfigurationSizes configurationSizes =
         new VariantTotalSizeAggregator(
-                ImmutableMap.of("sample.apk", 11L),
-                variant,
-                getSizeCommand
-                    .setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY, LANGUAGE, SDK))
-                    .setDeviceSpec(
-                        mergeSpecs(
-                            locales("fr", "jp"),
-                            abis("arm64-v8a", "mips"),
-                            density(MDPI),
-                            sdkVersion(15)))
-                    .build())
+            ImmutableMap.of("sample.apk", 11D),
+            variant,
+            getSizeCommand
+                .setDimensions(ImmutableSet.of(ABI, SCREEN_DENSITY, LANGUAGE, SDK))
+                .setDeviceSpec(
+                    mergeSpecs(
+                        locales("fr", "jp"),
+                        abis("arm64-v8a", "mips"),
+                        density(MDPI),
+                        sdkVersion(15)))
+                .build())
             .getSize();
     assertThat(configurationSizes.getMinSizeConfigurationMap())
         .isEqualTo(configurationSizes.getMaxSizeConfigurationMap());
@@ -700,6 +701,6 @@ public class VariantTotalSizeAggregatorTest {
                 .setLocale("fr,jp")
                 .setAbi("arm64-v8a,mips")
                 .build(),
-            11L);
+            11D);
   }
 }

--- a/src/test/java/com/android/tools/build/bundletool/model/utils/ApkSizeUtilsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/ApkSizeUtilsTest.java
@@ -17,6 +17,7 @@
 package com.android.tools.build.bundletool.model.utils;
 
 import static com.android.bundle.Targeting.Abi.AbiAlias.X86;
+import static com.android.tools.build.bundletool.commands.GetSizeCommand.GetSizeSubSubCommand.BYTES;
 import static com.android.tools.build.bundletool.model.utils.ApkSizeUtils.getCompressedSizeByApkPaths;
 import static com.android.tools.build.bundletool.testing.ApksArchiveHelpers.createApkDescription;
 import static com.android.tools.build.bundletool.testing.ApksArchiveHelpers.createApksArchiveFile;
@@ -32,6 +33,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.android.bundle.Commands.BuildApksResult;
 import com.android.bundle.Commands.Variant;
 import com.android.bundle.Targeting.ApkTargeting;
+import com.android.tools.build.bundletool.commands.GetSizeCommand;
 import com.android.tools.build.bundletool.io.ZipBuilder;
 import com.android.tools.build.bundletool.io.ZipBuilder.EntryOption;
 import com.android.tools.build.bundletool.model.ZipPath;
@@ -73,11 +75,11 @@ public class ApkSizeUtilsTest {
             BuildApksResult.newBuilder().addAllVariant(variants).build(),
             tmpDir.resolve("bundle.apks"));
 
-    ImmutableMap<String, Long> sizeByApkPaths =
-        getCompressedSizeByApkPaths(variants, apksArchiveFile);
+    ImmutableMap<String, Double> sizeByApkPaths =
+            getCompressedSizeByApkPaths(variants, apksArchiveFile, BYTES);
     assertThat(sizeByApkPaths.keySet()).containsExactly("apk_one.apk");
 
-    assertThat(sizeByApkPaths.get("apk_one.apk")).isAtLeast(1L);
+    assertThat(sizeByApkPaths.get("apk_one.apk")).isAtLeast(1D);
   }
 
   @Test
@@ -104,15 +106,14 @@ public class ApkSizeUtilsTest {
             BuildApksResult.newBuilder().addAllVariant(variants).build(),
             tmpDir.resolve("bundle.apks"));
 
-    ImmutableMap<String, Long> sizeByApkPaths =
-        getCompressedSizeByApkPaths(variants, apksArchiveFile);
+    ImmutableMap<String, Double> sizeByApkPaths = getCompressedSizeByApkPaths(variants, apksArchiveFile, BYTES);
     assertThat(sizeByApkPaths.keySet())
         .containsExactly("base.apk", "base-x86.apk", "feature.apk", "feature-x86.apk");
 
-    assertThat(sizeByApkPaths.get("base.apk")).isAtLeast(1L);
-    assertThat(sizeByApkPaths.get("base-x86.apk")).isAtLeast(1L);
-    assertThat(sizeByApkPaths.get("feature.apk")).isAtLeast(1L);
-    assertThat(sizeByApkPaths.get("feature-x86.apk")).isAtLeast(1L);
+    assertThat(sizeByApkPaths.get("base.apk")).isAtLeast(1D);
+    assertThat(sizeByApkPaths.get("base-x86.apk")).isAtLeast(1D);
+    assertThat(sizeByApkPaths.get("feature.apk")).isAtLeast(1D);
+    assertThat(sizeByApkPaths.get("feature-x86.apk")).isAtLeast(1D);
   }
 
   @Test
@@ -135,14 +136,13 @@ public class ApkSizeUtilsTest {
             BuildApksResult.newBuilder().addAllVariant(variants).build(),
             tmpDir.resolve("bundle.apks"));
 
-    ImmutableMap<String, Long> sizeByApkPaths =
-        getCompressedSizeByApkPaths(variants, apksArchiveFile);
+    ImmutableMap<String, Double> sizeByApkPaths = getCompressedSizeByApkPaths(variants, apksArchiveFile, BYTES);
     assertThat(sizeByApkPaths.keySet()).containsExactly("apk_one.apk", "apk_two.apk");
 
-    long apkOneSize = sizeByApkPaths.get("apk_one.apk");
-    long apkTwoSize = sizeByApkPaths.get("apk_two.apk");
-    assertThat(apkOneSize).isAtLeast(1L);
-    assertThat(apkTwoSize).isAtLeast(1L);
+    double apkOneSize = sizeByApkPaths.get("apk_one.apk");
+    double apkTwoSize = sizeByApkPaths.get("apk_two.apk");
+    assertThat(apkOneSize).isAtLeast(1D);
+    assertThat(apkTwoSize).isAtLeast(1D);
   }
 
   @Test
@@ -170,16 +170,16 @@ public class ApkSizeUtilsTest {
         ZipPath.create("toc.pb"), BuildApksResult.newBuilder().addAllVariant(variants).build());
     Path apksArchiveFile = archiveBuilder.writeTo(tmpDir.resolve("bundle.apks"));
 
-    ImmutableMap<String, Long> sizeByApkPaths =
-        getCompressedSizeByApkPaths(variants, apksArchiveFile);
+    ImmutableMap<String, Double> sizeByApkPaths =
+            getCompressedSizeByApkPaths(variants, apksArchiveFile, BYTES);
     assertThat(sizeByApkPaths.keySet()).containsExactly("apk_one.apk", "apk_two.apk");
 
-    long apkOneSize = sizeByApkPaths.get("apk_one.apk");
-    long apkTwoSize = sizeByApkPaths.get("apk_two.apk");
+    double apkOneSize = sizeByApkPaths.get("apk_one.apk");
+    double apkTwoSize = sizeByApkPaths.get("apk_two.apk");
     // Apks should have size at least 20. Gzip Header(10 bytes), deflated data (Min 2 Bytes for
     // empty file), 8 bytes footer.
-    assertThat(apkOneSize).isGreaterThan(20L);
-    assertThat(apkTwoSize).isGreaterThan(20L);
+    assertThat(apkOneSize).isGreaterThan(20D);
+    assertThat(apkTwoSize).isGreaterThan(20D);
     assertThat(apkOneSize).isEqualTo(apkTwoSize);
   }
 
@@ -204,10 +204,10 @@ public class ApkSizeUtilsTest {
             BuildApksResult.newBuilder().addAllVariant(variants).build(),
             tmpDir.resolve("bundle.apks"));
 
-    ImmutableMap<String, Long> sizeByApkPaths =
-        getCompressedSizeByApkPaths(ImmutableList.of(lVariant), apksArchiveFile);
+    ImmutableMap<String, Double> sizeByApkPaths =
+            getCompressedSizeByApkPaths(ImmutableList.of(lVariant), apksArchiveFile, BYTES);
     assertThat(sizeByApkPaths.keySet()).containsExactly("apk_one.apk");
 
-    assertThat(sizeByApkPaths.get("apk_one.apk")).isAtLeast(1L);
+    assertThat(sizeByApkPaths.get("apk_one.apk")).isAtLeast(1D);
   }
 }

--- a/src/test/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtilsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtilsTest.java
@@ -40,10 +40,10 @@ public class GetSizeCsvUtilsTest {
     assertThat(
             getSizeTotalOutputInCsv(
                 ConfigurationSizes.create(
-                    ImmutableMap.of(SizeConfiguration.getDefaultInstance(), 10L),
-                    ImmutableMap.of(SizeConfiguration.getDefaultInstance(), 15L)),
+                    ImmutableMap.of(SizeConfiguration.getDefaultInstance(), 10D),
+                    ImmutableMap.of(SizeConfiguration.getDefaultInstance(), 15D)),
                 ImmutableSet.of()))
-        .isEqualTo("MIN,MAX" + CRLF + "10,15" + CRLF);
+        .isEqualTo("MIN,MAX" + CRLF + "10.0,15.0" + CRLF);
   }
 
   @Test
@@ -53,23 +53,23 @@ public class GetSizeCsvUtilsTest {
                 ConfigurationSizes.create(
                     ImmutableMap.of(
                         SizeConfiguration.builder().setSdkVersion("21-").setAbi("x86").build(),
-                        5L,
+                        5D,
                         SizeConfiguration.builder()
                             .setSdkVersion("21-")
                             .setAbi("armeabi-v7a")
                             .build(),
-                        2L),
+                        2D),
                     ImmutableMap.of(
                         SizeConfiguration.builder().setSdkVersion("21-").setAbi("x86").build(),
-                        10L,
+                        10D,
                         SizeConfiguration.builder()
                             .setSdkVersion("21-")
                             .setAbi("armeabi-v7a")
                             .build(),
-                        15L)),
+                        15D)),
                 ImmutableSet.of(ABI, SDK)))
         .isEqualTo(
-            "SDK,ABI,MIN,MAX" + CRLF + "21-,x86,5,10" + CRLF + "21-,armeabi-v7a,2,15" + CRLF);
+            "SDK,ABI,MIN,MAX" + CRLF + "21-,x86,5.0,10.0" + CRLF + "21-,armeabi-v7a,2.0,15.0" + CRLF);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class GetSizeCsvUtilsTest {
                             .setScreenDensity("480")
                             .setLocale("en,fr")
                             .build(),
-                        1L),
+                        1D),
                     ImmutableMap.of(
                         SizeConfiguration.builder()
                             .setSdkVersion("22")
@@ -92,12 +92,12 @@ public class GetSizeCsvUtilsTest {
                             .setScreenDensity("480")
                             .setLocale("en,fr")
                             .build(),
-                        6L)),
+                        6D)),
                 ImmutableSet.of(SCREEN_DENSITY, ABI, LANGUAGE, SDK)))
         .isEqualTo(
             "SDK,ABI,SCREEN_DENSITY,LANGUAGE,MIN,MAX"
                 + CRLF
-                + "22,\"x86,armeabi-v7a\",480,\"en,fr\",1,6"
+                + "22,\"x86,armeabi-v7a\",480,\"en,fr\",1.0,6.0"
                 + CRLF);
   }
 }


### PR DESCRIPTION
**Summary:**
The diff addresses below changes:
1. Added support to get-size in BYTES, KB and MB
2. Set default size to be printed as MB
3. Coverted size param from Long to Double
4. Refactored test cases

**Resolves:**
https://github.com/google/bundletool/issues/65

**Test Plan:**
Verified through unit tests and by running below commands:
- bundletool get-size total --apks=test/bundle_release.apks
- bundletool get-size total BYTES --apks=test/bundle_release.apks
- bundletool get-size total KB --apks=test/bundle_release.apks
- bundletool get-size total MB --apks=test/bundle_release.apks

**Output:**
```
ketkigrag-C02W2131HTD7:libs ketkigrag$ java -cp bundletool-all.jar com.android.tools.build.bundletool.BundleToolMain get-size total --apks=test/bundle_release.apks
MIN,MAX
4.25,4.61
ketkigrag-C02W2131HTD7:libs ketkigrag$ java -cp bundletool-all.jar com.android.tools.build.bundletool.BundleToolMain get-size total BYTES --apks=test/bundle_release.apks
MIN,MAX
4461180.0,4834194.0
ketkigrag-C02W2131HTD7:libs ketkigrag$ java -cp bundletool-all.jar com.android.tools.build.bundletool.BundleToolMain get-size total KB --apks=test/bundle_release.apks
MIN,MAX
4356.61,4720.89
ketkigrag-C02W2131HTD7:libs ketkigrag$ java -cp bundletool-all.jar com.android.tools.build.bundletool.BundleToolMain get-size total MB --apks=test/bundle_release.apks
MIN,MAX
4.25,4.61

```