### PR TITLE
Do not ship dependency on AutoValue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,10 @@ dependencies {
     compile "com.android.tools.build:apkzlib:3.4.0-beta01"
     compile "com.android.tools.ddms:ddmlib:26.2.0"
 
+    compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
+
     shadow "com.android.tools.build:aapt2-proto:0.4.0"
-    shadow "com.google.auto.value:auto-value:1.5.2"
-    annotationProcessor "com.google.auto.value:auto-value:1.5.2"
     shadow "com.google.errorprone:error_prone_annotations:2.3.1"
     shadow "com.google.guava:guava:27.0.1-jre"
     shadow "com.google.protobuf:protobuf-java:3.4.0"
@@ -48,9 +49,10 @@ dependencies {
     compileMacOs "com.android.tools.build:aapt2:3.5.0-alpha03-5252756:osx"
     compileLinux "com.android.tools.build:aapt2:3.5.0-alpha03-5252756:linux"
 
+    testCompileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+    testAnnotationProcessor "com.google.auto.value:auto-value:1.6.5"
+
     testCompile "com.android.tools.build:aapt2-proto:0.4.0"
-    testCompile "com.google.auto.value:auto-value-annotations:1.5.2"
-    testAnnotationProcessor "com.google.auto.value:auto-value:1.5.2"
     testCompile "com.google.errorprone:error_prone_annotations:2.3.1"
     testCompile "com.google.guava:guava:27.0.1-jre"
     testCompile "com.google.truth.extensions:truth-java8-extension:0.42"


### PR DESCRIPTION
Its annotations are only needed at compile-time for the annotation processor.