### PR TITLE
Install-apks now has --push-splits-to option.

### DIFF
--- a/src/main/java/com/android/tools/build/bundletool/commands/BuildApksCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/BuildApksCommand.java
@@ -525,7 +525,7 @@ public abstract class BuildApksCommand {
     }
   }
 
-  private static Aapt2Command extractAapt2FromJar(Path tempDir) {
+  static Aapt2Command extractAapt2FromJar(Path tempDir) {
     return new SdkToolsLocator()
         .extractAapt2(tempDir)
         .map(Aapt2Command::createFromExecutablePath)

--- a/src/main/java/com/android/tools/build/bundletool/device/Device.java
+++ b/src/main/java/com/android/tools/build/bundletool/device/Device.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
@@ -61,6 +62,8 @@ public abstract class Device {
 
   public abstract void installApks(ImmutableList<Path> apks, InstallOptions installOptions);
 
+  public abstract void pushApks(ImmutableList<Path> apks, PushOptions installOptions);
+
   /** Options related to APK installation. */
   @Immutable
   @AutoValue
@@ -89,6 +92,39 @@ public abstract class Device {
       public abstract Builder setTimeout(Duration timeout);
 
       public abstract InstallOptions build();
+    }
+  }
+
+  /** Options related to APK installation. */
+  @Immutable
+  @AutoValue
+  @AutoValue.CopyAnnotations
+  public abstract static class PushOptions {
+    public abstract Path getDestinationPath();
+
+//    public abstract PrintStream getPrintStream();
+
+    public abstract Duration getTimeout();
+
+    public abstract Optional<String> getPackageName();
+
+    public static Builder builder() {
+      return new AutoValue_Device_PushOptions.Builder()
+              .setTimeout(DEFAULT_ADB_TIMEOUT);
+    }
+
+    /** Builder for {@link InstallOptions}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setDestinationPath(Path destinationPath);
+
+//      public abstract Builder setPrintStream(PrintStream printStream);
+
+      public abstract Builder setTimeout(Duration timeout);
+
+      public abstract Builder setPackageName(String packageName);
+
+      public abstract PushOptions build();
     }
   }
 }

--- a/src/main/java/com/android/tools/build/bundletool/model/Aapt2Command.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/Aapt2Command.java
@@ -19,14 +19,19 @@ package com.android.tools.build.bundletool.model;
 import com.android.tools.build.bundletool.model.utils.files.BufferedIo;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /** Exposes aapt2 commands used by Bundle Tool. */
 public interface Aapt2Command {
 
   void convertApkProtoToBinary(Path protoApk, Path binaryApk);
+  String getPackageNameFromApk(Path binaryApk);
 
   static Aapt2Command createFromExecutablePath(Path aapt2Path) {
     return new Aapt2Command() {
@@ -42,6 +47,34 @@ public interface Aapt2Command {
                 binaryApk.toString(),
                 protoApk.toString());
       }
+
+      // Try to match:
+      // package: name='me.example.dynamicfeatures' versionCode='3' versionName='1.0' platformBuildVersionName='' platformBuildVersionCode='' compileSdkVersion='28' compileSdkVersionCodename='9'
+      @Override
+      public String getPackageNameFromApk(Path binaryApk) {
+        AtomicReference<String> packageName = new AtomicReference<>();
+        try {
+          new CommandExecutor()
+                  .execute(line -> {
+                            if (line.startsWith("package: ")) {
+                              packageName.set(line.replaceAll(".* name='([^']+)'.*", "$1"));
+                            }
+                          },
+                          aapt2Path.toString(),
+                          "dump",
+                          "badging",
+                          binaryApk.toString()
+                  );
+        } catch (Aapt2Exception e) {
+          // dump badging returns with error code 1
+          // we don't care about the error,
+          // as long as we were able to parse the package name (below)
+        }
+        if (packageName.get() == null) {
+          throw new Aapt2Exception("Cannot find application id of APK.");
+        }
+        return packageName.get();
+      }
     };
   }
 
@@ -50,14 +83,18 @@ public interface Aapt2Command {
     private static final int TIMEOUT_AAPT2_COMMANDS_SECONDS = 5 * 60; // 5 minutes.
 
     public void execute(String... command) {
+      execute(System.err::println, command);
+    }
+
+    public void execute(Consumer<String> outputConsumer, String... command) {
       try {
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         if (!process.waitFor(TIMEOUT_AAPT2_COMMANDS_SECONDS, TimeUnit.SECONDS)) {
-          printOutput(process);
+          printOutput(process, outputConsumer);
           throw new Aapt2Exception("Command timed out: " + Arrays.toString(command));
         }
         if (process.exitValue() != 0) {
-          printOutput(process);
+          printOutput(process, outputConsumer);
           throw new Aapt2Exception(
               String.format(
                   "Command '%s' didn't terminate successfully (exit code: %d). Check the logs.",
@@ -68,11 +105,11 @@ public interface Aapt2Command {
       }
     }
 
-    private static void printOutput(Process process) {
+    private static void printOutput(Process process, Consumer<String> outputConsumer) {
       try (BufferedReader outputReader = BufferedIo.reader(process.getInputStream())) {
         String line;
         while ((line = outputReader.readLine()) != null) {
-          System.err.println(line);
+          outputConsumer.accept(line);
         }
       } catch (IOException e) {
         System.err.println("Error when printing output of aapt2 command:" + e.getMessage());

--- a/src/test/java/com/android/tools/build/bundletool/device/ApksInstallerTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/device/ApksInstallerTest.java
@@ -54,8 +54,8 @@ public class ApksInstallerTest {
         assertThrows(
             CommandExecutionException.class,
             () ->
-                apksInstaller.installApks(
-                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS));
+                apksInstaller.run(device -> device.installApks(
+                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS)));
     assertThat(exception)
         .hasMessageThat()
         .contains("Expected to find one connected device, but found none.");
@@ -71,7 +71,7 @@ public class ApksInstallerTest {
     testAdbServer.init(Paths.get("/test/adb"));
     ApksInstaller apksInstaller = new ApksInstaller(testAdbServer);
 
-    apksInstaller.installApks(ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS);
+    apksInstaller.run(device -> device.installApks(ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS));
   }
 
   @Test
@@ -89,8 +89,8 @@ public class ApksInstallerTest {
         assertThrows(
             CommandExecutionException.class,
             () ->
-                apksInstaller.installApks(
-                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS));
+                apksInstaller.run(device -> device.installApks(
+                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS)));
     assertThat(exception)
         .hasMessageThat()
         .contains("Expected to find one connected device, but found 2.");
@@ -107,8 +107,8 @@ public class ApksInstallerTest {
         assertThrows(
             CommandExecutionException.class,
             () ->
-                apksInstaller.installApks(
-                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS, "device1"));
+                apksInstaller.run(device -> device.installApks(
+                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS), "device1"));
     assertThat(exception)
         .hasMessageThat()
         .contains("Expected to find one connected device with serial number 'device1'.");
@@ -126,8 +126,8 @@ public class ApksInstallerTest {
     testAdbServer.init(Paths.get("/test/adb"));
     ApksInstaller apksInstaller = new ApksInstaller(testAdbServer);
 
-    apksInstaller.installApks(
-        ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS, "device1");
+    apksInstaller.run(device -> device.installApks(
+        ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS), "device1");
   }
 
   @Test
@@ -154,8 +154,8 @@ public class ApksInstallerTest {
         assertThrows(
             InstallationException.class,
             () ->
-                apksInstaller.installApks(
-                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS, "device2"));
+                apksInstaller.run(device -> device.installApks(
+                    ImmutableList.of(Paths.get("apkOne.apk")), DEFAULT_INSTALL_OPTIONS), "device2"));
     assertThat(exception)
         .hasMessageThat()
         .contains("Enable USB debugging on the connected device.");
@@ -177,8 +177,8 @@ public class ApksInstallerTest {
           }
         });
 
-    apksInstaller.installApks(
+    apksInstaller.run(device -> device.installApks(
         ImmutableList.of(Paths.get("apkOne.apk")),
-        InstallOptions.builder().setAllowDowngrade(true).build());
+        InstallOptions.builder().setAllowDowngrade(true).build()));
   }
 }

--- a/src/test/java/com/android/tools/build/bundletool/device/DdmlibDeviceTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/device/DdmlibDeviceTest.java
@@ -95,4 +95,12 @@ public final class DdmlibDeviceTest {
 
     assertThat(extraArgsCaptor.getValue()).contains("-d");
   }
+
+  @Test
+  public void pathToUnixStringTest() {
+    Path path = Paths.get("/", "splits", "mysplits");
+    assertThat(DdmlibDevice.pathToUnixString(path)).isEqualTo("/splits/mysplits");
+    path = Paths.get("splits", "mysplits");
+    assertThat(DdmlibDevice.pathToUnixString(path)).isEqualTo("splits/mysplits");
+  }
 }

--- a/src/test/java/com/android/tools/build/bundletool/model/Aapt2CommandTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/Aapt2CommandTest.java
@@ -1,0 +1,39 @@
+package com.android.tools.build.bundletool.model;
+
+import com.android.tools.build.bundletool.TestData;
+import com.android.tools.build.bundletool.testing.Aapt2Helper;
+import com.google.common.truth.Truth;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RunWith(JUnit4.class)
+public class Aapt2CommandTest {
+
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+  private Path tmpDir;
+
+  @Before
+  public void setUp() {
+    tmpDir = tmp.getRoot().toPath();
+  }
+
+  @Test
+  public void getPackageNameFromApk() throws IOException {
+    Aapt2Command aapt2Command = Aapt2Helper.getAapt2Command();
+    InputStream is = TestData.openStream("testdata/apk/com.test.app.apk");
+    Path apkFile = tmpDir.resolve("test.apk");
+    Files.copy(is, apkFile);
+    String packageName = aapt2Command.getPackageNameFromApk(apkFile);
+    Truth.assertThat(packageName).isEqualTo("com.test.app");
+  }
+}

--- a/src/test/java/com/android/tools/build/bundletool/testing/FakeDevice.java
+++ b/src/test/java/com/android/tools/build/bundletool/testing/FakeDevice.java
@@ -53,7 +53,8 @@ public class FakeDevice extends Device {
   private final String serialNumber;
   private final ImmutableMap<String, String> properties;
   private final Map<String, FakeShellCommandAction> commandInjections = new HashMap<>();
-  private Optional<SideEffect> installApksSideEffect = Optional.empty();
+  private Optional<SideEffect<InstallOptions>> installApksSideEffect = Optional.empty();
+  private Optional<SideEffect<PushOptions>> pushApksSideEffect = Optional.empty();
   private static final Joiner COMMA_JOINER = Joiner.on(',');
   private static final Joiner DASH_JOINER = Joiner.on('-');
   private static final Joiner LINE_JOINER = Joiner.on(System.getProperty("line.separator"));
@@ -211,8 +212,17 @@ public class FakeDevice extends Device {
     installApksSideEffect.ifPresent(val -> val.apply(apks, installOptions));
   }
 
-  public void setInstallApksSideEffect(SideEffect sideEffect) {
+  @Override
+  public void pushApks(ImmutableList<Path> apks, PushOptions pushOptions) {
+    pushApksSideEffect.ifPresent(val -> val.apply(apks, pushOptions));
+  }
+
+  public void setInstallApksSideEffect(SideEffect<InstallOptions> sideEffect) {
     installApksSideEffect = Optional.of(sideEffect);
+  }
+
+  public void setPushApksSideEffect(SideEffect<PushOptions> sideEffect) {
+    pushApksSideEffect = Optional.of(sideEffect);
   }
 
   public void clearInstallApksSideEffect() {
@@ -232,7 +242,7 @@ public class FakeDevice extends Device {
   }
 
   /** Side effect. */
-  public interface SideEffect {
-    void apply(ImmutableList<Path> apks, InstallOptions installOptions);
+  public interface SideEffect<T> {
+    void apply(ImmutableList<Path> apks, T options);
   }
 }


### PR DESCRIPTION
This is useful for pushing on-demand splits
for use with FakeSplitInstallManager.