### PR TITLE
Removed conditional operator test smell

### DIFF
--- a/src/test/java/com/android/tools/build/bundletool/model/utils/files/FilePreconditionsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/files/FilePreconditionsTest.java
@@ -22,6 +22,7 @@ import static com.android.tools.build.bundletool.model.utils.files.FilePrecondit
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileExistsAndReadable;
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileHasExtension;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.android.tools.build.bundletool.model.utils.OsPlatform;
@@ -29,6 +30,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,9 +72,7 @@ public class FilePreconditionsTest {
   @Test
   public void checkFileExistsAndReadable_nonReadable_fail() throws Exception {
     // "File.setReadable(false)" does not work on Windows.
-    if (OsPlatform.getCurrentPlatform().equals(OsPlatform.WINDOWS)) {
-      return;
-    }
+    assumeFalse(OsPlatform.getCurrentPlatform().equals(OsPlatform.WINDOWS));
 
     File unreadableFile = tmp.newFile();
     unreadableFile.setReadable(false);

--- a/src/test/java/com/android/tools/build/bundletool/model/utils/files/FilePreconditionsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/files/FilePreconditionsTest.java
@@ -22,7 +22,7 @@ import static com.android.tools.build.bundletool.model.utils.files.FilePrecondit
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileExistsAndReadable;
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileHasExtension;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assume.*;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.android.tools.build.bundletool.model.utils.OsPlatform;
@@ -30,7 +30,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;


### PR DESCRIPTION
This is a test refactoring.

**Problem:**
Conditions within the test method will alter the behavior of the test and its expected output, leading to situations where the test fails to detect defects in the production method since test statements were not executed as a condition was not met.

**Solution:**
Instead of using a conditional to control the test execution, we use the proper JUnit API with Assume.assumeFalse(). If the initial assumption is not met, the test will be ignored instead of passing without actually testing the code under test.

**Result:**

_Before:_
```
// "File.setReadable(false)" does not work on Windows.
if (OsPlatform.getCurrentPlatform().equals(OsPlatform.WINDOWS)) {
    return;
}
```
_After_
```
// "File.setReadable(false)" does not work on Windows.
assumeFalse(OsPlatform.getCurrentPlatform().equals(OsPlatform.WINDOWS));
```
