### PR TITLE
Support packaging baseline.prof from bundle to result apk

### DIFF
--- a/src/main/java/com/android/tools/build/bundletool/shards/StandaloneApksGenerator.java
+++ b/src/main/java/com/android/tools/build/bundletool/shards/StandaloneApksGenerator.java
@@ -28,6 +28,7 @@ import com.android.tools.build.bundletool.model.ModuleSplit.SplitType;
 import com.android.tools.build.bundletool.model.SourceStamp;
 import com.android.tools.build.bundletool.model.SourceStamp.StampType;
 import com.android.tools.build.bundletool.optimizations.ApkOptimizations;
+import com.android.tools.build.bundletool.splitters.BaselineProfileInjector;
 import com.android.tools.build.bundletool.splitters.CodeTransparencyInjector;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -45,6 +46,7 @@ public class StandaloneApksGenerator {
   private final Sharder sharder;
   private final ModuleSplitsToShardMerger shardsMerger;
   private final CodeTransparencyInjector codeTransparencyInjector;
+  private final BaselineProfileInjector baselineProfileInjector;
 
   @Inject
   public StandaloneApksGenerator(
@@ -58,6 +60,7 @@ public class StandaloneApksGenerator {
     this.sharder = sharder;
     this.shardsMerger = shardsMerger;
     this.codeTransparencyInjector = new CodeTransparencyInjector(appBundle);
+    baselineProfileInjector = new BaselineProfileInjector(appBundle);
   }
 
   /**
@@ -99,6 +102,7 @@ public class StandaloneApksGenerator {
         .map(StandaloneApksGenerator::setVariantTargetingAndSplitType)
         .map(this::writeSourceStampInManifest)
         .map(codeTransparencyInjector::inject)
+        .map(baselineProfileInjector::inject)
         .collect(toImmutableList());
   }
 

--- a/src/main/java/com/android/tools/build/bundletool/shards/SystemApksGenerator.java
+++ b/src/main/java/com/android/tools/build/bundletool/shards/SystemApksGenerator.java
@@ -37,6 +37,7 @@ import com.android.tools.build.bundletool.model.ModuleSplit.SplitType;
 import com.android.tools.build.bundletool.model.SuffixManager;
 import com.android.tools.build.bundletool.model.ZipPath;
 import com.android.tools.build.bundletool.optimizations.ApkOptimizations;
+import com.android.tools.build.bundletool.splitters.BaselineProfileInjector;
 import com.android.tools.build.bundletool.splitters.CodeTransparencyInjector;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -56,6 +57,7 @@ public class SystemApksGenerator {
   private final ModuleSplitsToShardMerger shardsMerger;
   private final Optional<DeviceSpec> deviceSpec;
   private final CodeTransparencyInjector codeTransparencyInjector;
+  private final BaselineProfileInjector baselineProfileInjector;
 
   @Inject
   public SystemApksGenerator(
@@ -69,6 +71,7 @@ public class SystemApksGenerator {
     this.shardsMerger = shardsMerger;
     this.deviceSpec = deviceSpec;
     this.codeTransparencyInjector = new CodeTransparencyInjector(appBundle);
+    baselineProfileInjector = new BaselineProfileInjector(appBundle);
   }
 
   /**
@@ -97,6 +100,7 @@ public class SystemApksGenerator {
 
     return processSplitsOfSystemShard(systemShard, modulesToFuse).stream()
         .map(module -> applyUncompressedOptimizations(module, apkOptimizations))
+        .map(baselineProfileInjector::inject)
         .map(codeTransparencyInjector::inject)
         .collect(toImmutableList());
   }

--- a/src/main/java/com/android/tools/build/bundletool/splitters/BaselineProfileInjector.java
+++ b/src/main/java/com/android/tools/build/bundletool/splitters/BaselineProfileInjector.java
@@ -1,0 +1,41 @@
+package com.android.tools.build.bundletool.splitters;
+
+import com.android.tools.build.bundletool.model.AppBundle;
+import com.android.tools.build.bundletool.model.ModuleSplit;
+
+/**
+ * Copies baseline.prof and baseline.profm from bundle metadata to apk in assets/dexopt directory.
+ * <p>
+ * Support both files placement options:
+ * <ul>
+ *     <li>BUNDLE-METADATA/assets/dexopt</li>
+ *     <li>BUNDLE-METADATA/com.android.tools.build.profiles</li>
+ * </ul>
+ */
+public class BaselineProfileInjector {
+
+    private final AppBundle appBundle;
+
+    public BaselineProfileInjector(AppBundle appBundle) {
+        this.appBundle = appBundle;
+    }
+
+    public ModuleSplit inject(ModuleSplit split) {
+        ModuleSplit.Builder splitBuilder = split.toBuilder();
+        if (shouldAddBaselineProfileToSplit(split)) {
+            appBundle
+                .getBundleMetadata()
+                .getBaselineProfiles()
+                .forEach(file -> file.ifPresent(splitBuilder::addEntry));
+        }
+        return splitBuilder.build();
+    }
+
+    private boolean shouldAddBaselineProfileToSplit(ModuleSplit split) {
+        if (split.getSplitType() == ModuleSplit.SplitType.STANDALONE) {
+            return true;
+        }
+        return split.isMasterSplit() && split.isBaseModuleSplit();
+    }
+
+}

--- a/src/main/java/com/android/tools/build/bundletool/splitters/ModuleSplitter.java
+++ b/src/main/java/com/android/tools/build/bundletool/splitters/ModuleSplitter.java
@@ -79,6 +79,7 @@ public class ModuleSplitter {
   private final AbiPlaceholderInjector abiPlaceholderInjector;
   private final PinSpecInjector pinSpecInjector;
   private final CodeTransparencyInjector codeTransparencyInjector;
+  private final BaselineProfileInjector baselineProfileInjector;
 
   @VisibleForTesting
   public static ModuleSplitter createForTest(BundleModule module, Version bundleVersion) {
@@ -152,6 +153,7 @@ public class ModuleSplitter {
         new AbiPlaceholderInjector(apkGenerationConfiguration.getAbisForPlaceholderLibs());
     this.pinSpecInjector = new PinSpecInjector(module);
     this.codeTransparencyInjector = new CodeTransparencyInjector(appBundle);
+    baselineProfileInjector = new BaselineProfileInjector(appBundle);
     this.allModuleNames = allModuleNames;
     this.stampSource = stampSource;
     this.stampType = stampType;
@@ -200,6 +202,7 @@ public class ModuleSplitter {
         runSplitters().stream()
             .map(pinSpecInjector::inject)
             .map(codeTransparencyInjector::inject)
+            .map(baselineProfileInjector::inject)
             .map(this::addApkTargetingForSigningConfiguration)
             .map(this::addLPlusApkTargeting)
             .map(this::writeSplitIdInManifest)


### PR DESCRIPTION
Currently bundletool does not support to put `baseline.prof` and `baseline.profm` from `BUNDLE-METADATA` into generated apks. For more info: https://issuetracker.google.com/issues/230361284, https://issuetracker.google.com/issues/226434396.

This PR adds support to packaging `baseline.prof` and `baseline.profm` files from bundle metadata to generated apk. Supports both locations in `BUNDLE-METADATA`: `/assets/dexopt` and `com.android.tools.build.profiles`.

This PR does not contain tests for now because I want to be sure that my solution is good enough.