### PR TITLE
current locale has different decimal separator

### DIFF
--- a/src/test/java/com/android/tools/build/bundletool/commands/PrintDeviceTargetingConfigCommandTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/commands/PrintDeviceTargetingConfigCommandTest.java
@@ -29,6 +29,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.nio.file.Path;
+import java.util.Locale;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +48,7 @@ public class PrintDeviceTargetingConfigCommandTest {
   @Before
   public void setUp() {
     Path tmpDir = tmp.getRoot().toPath();
+    Locale.setDefault(Locale.forLanguageTag("en-US"));
     deviceTargetingConfigPath = tmpDir.resolve("config.json");
   }
 

--- a/src/test/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtilsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/GetSizeCsvUtilsTest.java
@@ -32,12 +32,20 @@ import com.android.tools.build.bundletool.model.ConfigurationSizes;
 import com.android.tools.build.bundletool.model.SizeConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Locale;
+
 @RunWith(JUnit4.class)
 public class GetSizeCsvUtilsTest {
+
+  @Before
+  public void setUp() {
+    Locale.setDefault(Locale.forLanguageTag("en-US"));
+  }
 
   @Test
   public void getSizeTotalOutputInCsv_emptyDimensions() {

--- a/src/test/java/com/android/tools/build/bundletool/model/utils/SizeFormatterTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/SizeFormatterTest.java
@@ -17,12 +17,21 @@ package com.android.tools.build.bundletool.model.utils;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.nio.file.Path;
+import java.util.Locale;
+
 @RunWith(JUnit4.class)
 public class SizeFormatterTest {
+
+  @Before
+  public void setUp() {
+    Locale.setDefault(Locale.forLanguageTag("en-US"));
+  }
 
   @Test
   public void rawFormatter() {


### PR DESCRIPTION
if the current locale has a decimal separator not a dot then three tests FAIL

For example

```bash
expected:
    …m':
      (
        RAM >= 4.00 GB
      )
      …
but was:
    …m':
      (
        RAM >= 4,00 GB
      )
```

all tests changed for not to depend on the execution order