### PR TITLE
Since Java SE 17 old language codes not converted

### DIFF
--- a/src/test/java/com/android/tools/build/bundletool/model/utils/ResourcesUtilsTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/model/utils/ResourcesUtilsTest.java
@@ -246,10 +246,13 @@ public class ResourcesUtilsTest {
   public void resourcesLocaleConversions_oldLanguageCodes() {
     // This documents that our converter will use old ISO-639 language codes for backward
     // compatibility.
+    // Since Java SE 17, this is no longer the case.
 
-    assertThat(ResourcesUtils.convertLocaleToLanguage("he")).isEqualTo("iw");
-    assertThat(ResourcesUtils.convertLocaleToLanguage("yi")).isEqualTo("ji");
-    assertThat(ResourcesUtils.convertLocaleToLanguage("id")).isEqualTo("in");
+    if (System.getProperty("java.version").compareTo("17") < 0) {
+      assertThat(ResourcesUtils.convertLocaleToLanguage("he")).isEqualTo("iw");
+      assertThat(ResourcesUtils.convertLocaleToLanguage("yi")).isEqualTo("ji");
+      assertThat(ResourcesUtils.convertLocaleToLanguage("id")).isEqualTo("in");
+    }
   }
 
   @Test


### PR DESCRIPTION
According to SDK documentation Since Java SE 17 locale's constructor not converted three language codes to their earlier values.

Added conditional execution for SDK <17