### PR TITLE
Upgrade protobuf gradle plugin to 0.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.13"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
         classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.1"
     }
 }


### PR DESCRIPTION
Since Protobuf Gradle Plugin 0.9.0, the generated proto java classes can be automatically added to the project sourceset, so that the files can be correctly indexed by the IDE.