### PR TITLE
Add bundletool version check when adding transparency file

### DIFF
--- a/src/main/java/com/android/tools/build/bundletool/transparency/CodeTransparencyFactory.java
+++ b/src/main/java/com/android/tools/build/bundletool/transparency/CodeTransparencyFactory.java
@@ -26,6 +26,7 @@ import com.android.tools.build.bundletool.model.AppBundle;
 import com.android.tools.build.bundletool.model.BundleModule;
 import com.android.tools.build.bundletool.model.ModuleEntry;
 import com.android.tools.build.bundletool.model.exceptions.InvalidBundleException;
+import com.android.tools.build.bundletool.model.version.BundleToolVersion;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
@@ -51,8 +52,13 @@ public final class CodeTransparencyFactory {
         CodeTransparency.newBuilder()
             .setVersion(CodeTransparencyVersion.getCurrentVersion())
             .addAllCodeRelatedFile(codeRelatedFiles);
-
     if (bundle.getStoreArchive().orElse(true)) {
+      if (BundleToolVersion.getCurrentVersion().compareTo(bundle.getVersion()) <= 0) {
+        throw InvalidBundleException.builder()
+                .withUserMessage("This bundletool version is lower than the one that is used to build the app bundle. " +
+                        "Please use a bundletool with version >= " + bundle.getVersion())
+                .build();
+      }
       codeTransparencyBuilder.addCodeRelatedFile(createArchivedCodeRelatedFile(bundle));
     }
 


### PR DESCRIPTION
There is a bundletool compatibility issue when 
1. the bundle is built by a newer bundletool version through AGP.
2. later is added the code transparency file with a older bundletool version.
3. finally build apks with a newer bundletool version again. There will be error saying storearchive related dex is modified. 

For example, I build an app bundle with AGP 8.5 (which uses bundletool 1.16.0 implicitly). Then I manually add the code transparency file using bundletool 1.15.0. Then, when I try to upload the bundle to play store, or use bundletool build-apks, there will be an error saying ` We have failed to run 'bundletool build-apks' on this Android App Bundle. Please ensure your bundle is valid by running 'bundletool build-apks' locally and try again. Error message output: Verification failed because code was modified after transparency metadata generation. 
Files deleted after transparency metadata generation: [/com/android/tools/build/bundletool/archive/dex/1_13_0/classes.dex]
Files added after transparency metadata generation: [/com/android/tools/build/bundletool/archive/dex/1_16_0/classes.dex]
Files modified after transparency metadata generation: []
`

### The root cause
bundletool 1.15.0 and 1.16.0 provides different archive dex files. If the bundle is built by a newer bundletool but the code transparency is added by an older bundletool, there will be potential conflict in the archive dex if the apks is generated by a new bundletool.

### How to fix
Add a checker for bundle versions between the bundle and bundletool when generating the archive dex path to make sure archive dex version is correctly matched with the bundle version.

 