### PR TITLE
Update apksig to 8.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ configurations {
 dependencies {
     implementation "com.android.tools:common:31.3.0-alpha14"
     implementation "com.android.tools:r8:3.3.28"
-    implementation "com.android.tools.build:apksig:4.2.0-alpha13"
+    implementation "com.android.tools.build:apksig:8.5.1"
     implementation "com.android.tools.ddms:ddmlib:31.3.0-alpha14"
     implementation "com.android:zipflinger:7.1.0-alpha07"
 


### PR DESCRIPTION
apksig 4.2.0-alpha13 doesn’t support the v3.1 signature scheme, causing an APK signed with that scheme to fail validation with the following error:
```
APK Signature Scheme v3 signers supported min/max SDK versions do not cover the entire desired range.  Found min:  24 max 32
```

(v3.1 is supported in API 33+). We discovered this when running `java -jar bundle tool.jar check-transparency --mode=connected_device --package-name="com.example.mypackage"` with an APK installed from the Play Store.
