### PR TITLE
'get-size exact' subcommand for size estimation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,15 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     compileJava.options.release = 8;
 }
 
+// Add protobuf generated sources for correct importing project in the JntelliJ
+sourceSets {
+    main {
+        java {
+            srcDirs 'build/generated/source/proto/main/java'
+        }
+    }
+}
+
 test {
     if (osName.contains("linux")) {
         environment "AAPT2_PATH", "build/resources/main/linux/aapt2"

--- a/docs/exact-size-command.md
+++ b/docs/exact-size-command.md
@@ -1,0 +1,25 @@
+# Context
+
+There is a command in the [bundletool](https://developer.android.com/tools/bundletool) to measure the estimated download
+sizes of APKs in an APK set as they would be served compressed over the wire:
+
+```shell
+java -jar bundletool.jar get-size total --apks=/MyApp/my_app.apks --modules=my_on_demand_module
+```
+
+The command by default includes all install-time modules in the estimation (see [`ApkMatcher#getRequestedModules`](../src/main/java/com/android/tools/build/bundletool/device/ApkMatcher.java)).
+Additional on-demand modules can be included by specifying the `--modules` argument.
+
+# Problem statement
+While the `total` estimation is suitable for alerting systems to keep the app within [Google Play size limits](https://support.google.com/googleplay/android-developer/answer/9859372),
+it may also be useful to estimate the app size that most users actually get. The command `get-size total` does not suit this
+use case as it estimates the worst-case scenario, treating [conditional install-time](https://developer.android.com/guide/playcore/feature-delivery/conditional)
+modules as install-time ones even though they are configured for a narrow audience (specific region, OS API level, etc.).
+
+# Solution
+To address this, `get-size` can be extended with the `exact` subcommand, which calculates the size only for the modules
+explicitly specified via the `--modules` argument, keeping the `total` subcommand untouched.
+
+```shell
+java -jar bundletool.jar get-size exact --apks=/MyApp/my_app.apks --modules=base,widely_used_on_demand_module
+```

--- a/src/main/java/com/android/tools/build/bundletool/commands/ExtractApksCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/ExtractApksCommand.java
@@ -44,6 +44,7 @@ import com.android.tools.build.bundletool.device.DeviceSpecParser;
 import com.android.tools.build.bundletool.flags.Flag;
 import com.android.tools.build.bundletool.flags.ParsedFlags;
 import com.android.tools.build.bundletool.model.AndroidManifest;
+import com.android.tools.build.bundletool.model.ModulesResolutionMode;
 import com.android.tools.build.bundletool.model.exceptions.IncompatibleDeviceException;
 import com.android.tools.build.bundletool.model.exceptions.InvalidCommandException;
 import com.android.tools.build.bundletool.model.utils.FileNames;
@@ -213,6 +214,7 @@ public abstract class ExtractApksCommand {
         new ApkMatcher(
             deviceSpec,
             requestedModuleNames,
+            ModulesResolutionMode.TOTAL,
             getIncludeInstallTimeAssetModules(),
             getInstant(),
             /* ensureDensityAndAbiApksMatched= */ true);

--- a/src/main/java/com/android/tools/build/bundletool/commands/GetSizeCommand.java
+++ b/src/main/java/com/android/tools/build/bundletool/commands/GetSizeCommand.java
@@ -40,6 +40,7 @@ import com.android.tools.build.bundletool.flags.Flag;
 import com.android.tools.build.bundletool.flags.ParsedFlags;
 import com.android.tools.build.bundletool.model.ConfigurationSizes;
 import com.android.tools.build.bundletool.model.GetSizeRequest;
+import com.android.tools.build.bundletool.model.ModulesResolutionMode;
 import com.android.tools.build.bundletool.model.SizeConfiguration;
 import com.android.tools.build.bundletool.model.exceptions.InvalidCommandException;
 import com.android.tools.build.bundletool.model.utils.ConfigurationSizesMerger;
@@ -66,7 +67,8 @@ public abstract class GetSizeCommand implements GetSizeRequest {
 
   /** Sub commands supported on {@link GetSizeCommand}. */
   public enum GetSizeSubcommand {
-    TOTAL("total");
+    TOTAL("total"),
+    EXACT("exact");
 
     static final ImmutableMap<String, GetSizeSubcommand> STRING_TO_SUBCOMMAND =
         Arrays.stream(GetSizeSubcommand.values())
@@ -139,6 +141,13 @@ public abstract class GetSizeCommand implements GetSizeRequest {
   /** Gets whether to format sizes to human readable units. */
   public abstract boolean getHumanReadableSizes();
 
+  @Override
+  public ModulesResolutionMode getModulesResolutionMode() {
+    return getGetSizeSubCommand() == GetSizeSubcommand.EXACT
+        ? ModulesResolutionMode.EXACT
+        : ModulesResolutionMode.TOTAL;
+  }
+
   public static Builder builder() {
     return new AutoValue_GetSizeCommand.Builder()
         .setDeviceSpec(DeviceSpec.getDefaultInstance())
@@ -196,11 +205,18 @@ public abstract class GetSizeCommand implements GetSizeRequest {
             .map(DeviceSpecParser::parsePartialDeviceSpec)
             .orElse(DeviceSpec.getDefaultInstance());
 
+    GetSizeSubcommand subCommand = parseGetSizeSubCommand(flags);
+    if (subCommand == GetSizeSubcommand.EXACT && !modules.isPresent()) {
+      throw InvalidCommandException.builder()
+          .withInternalMessage("Flag --modules is required for 'exact' size estimation")
+          .build();
+    }
+
     GetSizeCommand.Builder command =
         builder()
             .setApksArchivePath(apksArchivePath)
             .setDeviceSpec(deviceSpec)
-            .setGetSizeSubCommand(parseGetSizeSubCommand(flags));
+            .setGetSizeSubCommand(subCommand);
 
     modules.ifPresent(command::setModules);
 
@@ -232,8 +248,11 @@ public abstract class GetSizeCommand implements GetSizeRequest {
   public void execute() {
     switch (getGetSizeSubCommand()) {
       case TOTAL:
+      case EXACT:
         getSizeTotal(System.out);
         break;
+      default:
+        throw new AssertionError("Unhandled subcommand: " + getGetSizeSubCommand());
     }
   }
 

--- a/src/main/java/com/android/tools/build/bundletool/device/ApkMatcher.java
+++ b/src/main/java/com/android/tools/build/bundletool/device/ApkMatcher.java
@@ -34,6 +34,7 @@ import com.android.bundle.Commands.Variant;
 import com.android.bundle.Devices.DeviceSpec;
 import com.android.bundle.Targeting.ApkTargeting;
 import com.android.tools.build.bundletool.model.ModuleSplit;
+import com.android.tools.build.bundletool.model.ModulesResolutionMode;
 import com.android.tools.build.bundletool.model.OptimizationDimension;
 import com.android.tools.build.bundletool.model.ZipPath;
 import com.android.tools.build.bundletool.model.exceptions.IncompatibleDeviceException;
@@ -54,6 +55,7 @@ public class ApkMatcher {
   private final ImmutableList<? extends TargetingDimensionMatcher<?>> apkMatchers;
 
   private final Optional<ImmutableSet<String>> requestedModuleNames;
+  private final ModulesResolutionMode modulesResolutionMode;
   private final boolean matchInstant;
   private final boolean includeInstallTimeAssetModules;
   private final ModuleMatcher moduleMatcher;
@@ -64,6 +66,7 @@ public class ApkMatcher {
     this(
         deviceSpec,
         Optional.empty(),
+        ModulesResolutionMode.TOTAL,
         /* includeInstallTimeAssetModules= */ true,
         /* matchInstant= */ false,
         /* ensureDensityAndAbiApksMatched= */ false);
@@ -74,6 +77,7 @@ public class ApkMatcher {
    *
    * @param deviceSpec given device configuration
    * @param requestedModuleNames sets of modules to match, all modules if empty
+   * @param modulesResolutionMode controls whether install-time modules are auto-included
    * @param matchInstant when set, matches APKs for instant modules only
    * @param ensureDensityAndAbiApksMatched when set, ensures one density split and/or one ABI split
    *     are matched per each module (if module has such splits) and throws
@@ -82,12 +86,16 @@ public class ApkMatcher {
   public ApkMatcher(
       DeviceSpec deviceSpec,
       Optional<ImmutableSet<String>> requestedModuleNames,
+      ModulesResolutionMode modulesResolutionMode,
       boolean includeInstallTimeAssetModules,
       boolean matchInstant,
       boolean ensureDensityAndAbiApksMatched) {
     checkArgument(
         !requestedModuleNames.isPresent() || !requestedModuleNames.get().isEmpty(),
         "Set of requested split modules cannot be empty.");
+    checkArgument(
+        modulesResolutionMode != ModulesResolutionMode.EXACT || requestedModuleNames.isPresent(),
+        "EXACT resolution mode requires modules to be specified.");
     SdkVersionMatcher sdkVersionMatcher = new SdkVersionMatcher(deviceSpec);
     AbiMatcher abiMatcher = new AbiMatcher(deviceSpec);
     MultiAbiMatcher multiAbiMatcher = new MultiAbiMatcher(deviceSpec);
@@ -114,6 +122,7 @@ public class ApkMatcher {
             deviceTierApkMatcher,
             countrySetApkMatcher);
     this.requestedModuleNames = requestedModuleNames;
+    this.modulesResolutionMode = modulesResolutionMode;
     this.includeInstallTimeAssetModules = includeInstallTimeAssetModules;
     this.matchInstant = matchInstant;
     this.ensureDensityAndAbiApksMatched = ensureDensityAndAbiApksMatched;
@@ -165,7 +174,7 @@ public class ApkMatcher {
     ImmutableSet<String> modulesToMatch =
         matchInstant
             ? getRequestedInstantModulesWithDependencies(variant)
-            : getInstallTimeAndRequestedModulesWithDependencies(variant, bundleVersion);
+            : getRequestedModules(variant, bundleVersion);
 
     return variant.getApkSetList().stream()
         .filter(apkSet -> modulesToMatch.contains(apkSet.getModuleMetadata().getName()))
@@ -231,11 +240,17 @@ public class ApkMatcher {
           .map(apkSet -> apkSet.getModuleMetadata().getName())
           .collect(toImmutableSet());
     }
+    if (modulesResolutionMode == ModulesResolutionMode.EXACT) {
+        return requestedModuleNames.get();
+    }
     return getModulesIncludingDependencies(variant, requestedModuleNames.get());
   }
 
-  private ImmutableSet<String> getInstallTimeAndRequestedModulesWithDependencies(
+  private ImmutableSet<String> getRequestedModules(
       Variant variant, Version bundleVersion) {
+    if (modulesResolutionMode == ModulesResolutionMode.EXACT) {
+        return requestedModuleNames.get();
+    }
     ImmutableSet<String> installTimeModules =
         buildModulesDeliveredInstallTime(variant, bundleVersion);
     ImmutableSet<String> explicitlyRequested = requestedModuleNames.orElse(ImmutableSet.of());

--- a/src/main/java/com/android/tools/build/bundletool/device/AssetModuleSizeAggregator.java
+++ b/src/main/java/com/android/tools/build/bundletool/device/AssetModuleSizeAggregator.java
@@ -130,6 +130,7 @@ public class AssetModuleSizeAggregator extends AbstractSizeAggregator {
                 countrySetTargeting,
                 sdkRuntimeTargeting),
             getSizeRequest.getModules(),
+            getSizeRequest.getModulesResolutionMode(),
             /* includeInstallTimeAssetModules= */ !getSizeRequest.getModules().isPresent(),
             getSizeRequest.getInstant(),
             /* ensureDensityAndAbiApksMatched= */ false)

--- a/src/main/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregator.java
+++ b/src/main/java/com/android/tools/build/bundletool/device/VariantTotalSizeAggregator.java
@@ -95,6 +95,7 @@ public class VariantTotalSizeAggregator extends AbstractSizeAggregator {
                 countrySetTargeting,
                 sdkRuntimeTargeting),
             getSizeRequest.getModules(),
+            getSizeRequest.getModulesResolutionMode(),
             /* includeInstallTimeAssetModules= */ false,
             getSizeRequest.getInstant(),
             /* ensureDensityAndAbiApksMatched= */ false)

--- a/src/main/java/com/android/tools/build/bundletool/model/GetSizeRequest.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/GetSizeRequest.java
@@ -49,4 +49,6 @@ public interface GetSizeRequest {
 
   /** Gets whether instant APKs should be used for size calculation. */
   boolean getInstant();
+
+  ModulesResolutionMode getModulesResolutionMode();
 }

--- a/src/main/java/com/android/tools/build/bundletool/model/ModulesResolutionMode.java
+++ b/src/main/java/com/android/tools/build/bundletool/model/ModulesResolutionMode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.tools.build.bundletool.model;
+
+/** Controls how the modules specified via {@code --modules} are resolved during size calculation. */
+public enum ModulesResolutionMode {
+  /**
+   * Treats --modules as additional to the installation time modules. Install-time modules and
+   * their dependencies are always included alongside any explicitly requested modules.
+   */
+  TOTAL,
+
+  /**
+   * Uses only the explicitly specified modules. Install-time modules are not automatically included
+   * and dependency resolution is skipped — the caller controls the exact set of modules to measure.
+   */
+  EXACT
+}

--- a/src/test/java/com/android/tools/build/bundletool/commands/GetSizeCommandTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/commands/GetSizeCommandTest.java
@@ -1810,6 +1810,143 @@ public final class GetSizeCommandTest {
                 "21-", "Not Required", 2 * compressedApkSize, 2 * compressedApkSize));
   }
 
+  @Test
+  public void exactSubcommand_withModules_parsedCorrectly() throws Exception {
+    BuildApksResult tableOfContentsProto = BuildApksResult.getDefaultInstance();
+    Path apksArchiveFile =
+        createApksArchiveFile(tableOfContentsProto, tmpDir.resolve("bundle.apks"));
+
+    GetSizeCommand fromFlags =
+        GetSizeCommand.fromFlags(
+            new FlagParser()
+                .parse("get-size", "exact", "--apks=" + apksArchiveFile, "--modules=base,feature1"));
+
+    GetSizeCommand fromBuilderApi =
+        GetSizeCommand.builder()
+            .setApksArchivePath(apksArchiveFile)
+            .setModules(ImmutableSet.of("base", "feature1"))
+            .setGetSizeSubCommand(GetSizeSubcommand.EXACT)
+            .build();
+
+    assertThat(fromFlags).isEqualTo(fromBuilderApi);
+  }
+
+  @Test
+  public void exactSubcommand_withoutModules_throwsInvalidCommandException() throws Exception {
+    BuildApksResult tableOfContentsProto = BuildApksResult.getDefaultInstance();
+    Path apksArchiveFile =
+        createApksArchiveFile(tableOfContentsProto, tmpDir.resolve("bundle.apks"));
+
+    InvalidCommandException exception =
+        assertThrows(
+            InvalidCommandException.class,
+            () ->
+                GetSizeCommand.fromFlags(
+                    new FlagParser().parse("get-size", "exact", "--apks=" + apksArchiveFile)));
+
+    assertThat(exception).hasMessageThat().contains("--modules is required for 'exact' size estimation");
+  }
+
+  @Test
+  public void getSizeExact_excludesInstallTimeModulesNotExplicitlyRequested() throws Exception {
+    // base is install-time; feature1 is on-demand; feature2 is install-time.
+    Variant lVariant =
+        createVariant(
+            lPlusVariantTargeting(),
+            createSplitApkSet(
+                /* moduleName= */ "base",
+                createMasterApkDescription(
+                    ApkTargeting.getDefaultInstance(), ZipPath.create("base-master.apk"))),
+            createSplitApkSet(
+                /* moduleName= */ "feature1",
+                DeliveryType.ON_DEMAND,
+                /* moduleDependencies= */ ImmutableList.of(),
+                createMasterApkDescription(
+                    ApkTargeting.getDefaultInstance(), ZipPath.create("base-feature1.apk"))),
+            createSplitApkSet(
+                /* moduleName= */ "feature2",
+                DeliveryType.INSTALL_TIME,
+                /* moduleDependencies= */ ImmutableList.of(),
+                createMasterApkDescription(
+                    ApkTargeting.getDefaultInstance(), ZipPath.create("base-feature2.apk"))));
+
+    BuildApksResult tableOfContentsProto =
+        BuildApksResult.newBuilder()
+            .setBundletool(
+                Bundletool.newBuilder()
+                    .setVersion(BundleToolVersion.getCurrentVersion().toString()))
+            .addVariant(lVariant)
+            .build();
+    Path apksArchiveFile =
+        createApksArchiveFile(tableOfContentsProto, tmpDir.resolve("bundle.apks"));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // EXACT with only feature1: install-time base and feature2 are not included.
+    GetSizeCommand.builder()
+        .setGetSizeSubCommand(GetSizeSubcommand.EXACT)
+        .setApksArchivePath(apksArchiveFile)
+        .setModules(ImmutableSet.of("feature1"))
+        .build()
+        .getSizeTotal(new PrintStream(outputStream));
+
+    assertThat(new String(outputStream.toByteArray(), UTF_8))
+        .isEqualTo(
+            "MIN,MAX"
+                + CRLF
+                + String.format("%d,%d", compressedApkSize, compressedApkSize)
+                + CRLF);
+  }
+
+  @Test
+  public void getSizeExact_installTimeAndOnDemandModules() throws Exception {
+    // base is install-time; feature1 is on-demand; feature2 is install-time.
+    Variant lVariant =
+      createVariant(
+          lPlusVariantTargeting(),
+          createSplitApkSet(
+              /* moduleName= */ "base",
+              createMasterApkDescription(
+                  ApkTargeting.getDefaultInstance(), ZipPath.create("base-master.apk"))),
+          createSplitApkSet(
+              /* moduleName= */ "feature1",
+              DeliveryType.ON_DEMAND,
+              /* moduleDependencies= */ ImmutableList.of(),
+              createMasterApkDescription(
+                  ApkTargeting.getDefaultInstance(), ZipPath.create("base-feature1.apk"))),
+          createSplitApkSet(
+              /* moduleName= */ "feature2",
+              DeliveryType.INSTALL_TIME,
+              /* moduleDependencies= */ ImmutableList.of(),
+              createMasterApkDescription(
+                  ApkTargeting.getDefaultInstance(), ZipPath.create("base-feature2.apk"))));
+
+    BuildApksResult tableOfContentsProto =
+        BuildApksResult.newBuilder()
+            .setBundletool(
+                Bundletool.newBuilder()
+                    .setVersion(BundleToolVersion.getCurrentVersion().toString()))
+            .addVariant(lVariant)
+            .build();
+    Path apksArchiveFile =
+        createApksArchiveFile(tableOfContentsProto, tmpDir.resolve("bundle.apks"));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    // EXACT with base + feature2
+    GetSizeCommand.builder()
+        .setGetSizeSubCommand(GetSizeSubcommand.EXACT)
+        .setApksArchivePath(apksArchiveFile)
+        .setModules(ImmutableSet.of("base", "feature2"))
+        .build()
+        .getSizeTotal(new PrintStream(outputStream));
+
+    assertThat(new String(outputStream.toByteArray(), UTF_8))
+        .isEqualTo(
+            "MIN,MAX"
+                + CRLF
+                + String.format("%d,%d", 2 * compressedApkSize, 2 * compressedApkSize)
+                + CRLF);
+  }
+
   /** Copies the testdata resource into the temporary directory. */
   private Path copyToTempDir(String testDataPath) throws Exception {
     Path testDataFilename = Paths.get(testDataPath).getFileName();

--- a/src/test/java/com/android/tools/build/bundletool/device/ApkMatcherTest.java
+++ b/src/test/java/com/android/tools/build/bundletool/device/ApkMatcherTest.java
@@ -99,6 +99,7 @@ import com.android.tools.build.bundletool.model.AndroidManifest;
 import com.android.tools.build.bundletool.model.BundleModuleName;
 import com.android.tools.build.bundletool.model.ModuleSplit;
 import com.android.tools.build.bundletool.model.ModuleSplit.SplitType;
+import com.android.tools.build.bundletool.model.ModulesResolutionMode;
 import com.android.tools.build.bundletool.model.ZipPath;
 import com.android.tools.build.bundletool.model.exceptions.IncompatibleDeviceException;
 import com.android.tools.build.bundletool.model.exceptions.InvalidCommandException;
@@ -1758,6 +1759,18 @@ public class ApkMatcherTest {
             matchedApk(installTimeMasterApk1, installTimeModule1, INSTALL_TIME),
             matchedApk(installTimeEnApk1, installTimeModule1, INSTALL_TIME),
             matchedApk(onDemandMasterApk, onDemandModule, ON_DEMAND));
+
+    assertThat(
+            createExactModulesMatcher(
+                    enDevice, Optional.of(ImmutableSet.of(installTimeModule1, onDemandModule)))
+                    .getMatchingApks(buildApksResult))
+            .containsExactly(
+                    // base has not been specified for the 'exact' modules selection
+                    matchedApk(installTimeMasterApk1, installTimeModule1, INSTALL_TIME),
+                    matchedApk(installTimeEnApk1, installTimeModule1, INSTALL_TIME),
+                    matchedApk(installTimeMasterApk2, installTimeModule2, INSTALL_TIME),
+                    matchedApk(installTimeEnApk2, installTimeModule2, INSTALL_TIME),
+                    matchedApk(onDemandMasterApk, onDemandModule, ON_DEMAND));
   }
 
   @Test
@@ -1869,6 +1882,7 @@ public class ApkMatcherTest {
     return new ApkMatcher(
         spec,
         modules,
+        ModulesResolutionMode.TOTAL,
         /* includeInstallTimeAssetModules= */ true,
         /* matchInstant= */ false,
         /* ensureDensityAndAbiApksMatched= */ false);
@@ -1879,6 +1893,7 @@ public class ApkMatcherTest {
     return new ApkMatcher(
         spec,
         modules,
+        ModulesResolutionMode.TOTAL,
         /* includeInstallTimeAssetModules= */ false,
         /* matchInstant= */ false,
         /* ensureDensityAndAbiApksMatched= */ false);
@@ -1889,6 +1904,7 @@ public class ApkMatcherTest {
     return new ApkMatcher(
         spec,
         modules,
+        ModulesResolutionMode.TOTAL,
         /* includeInstallTimeAssetModules= */ true,
         /* matchInstant= */ true,
         /* ensureDensityAndAbiApksMatched= */ false);
@@ -1899,8 +1915,20 @@ public class ApkMatcherTest {
     return new ApkMatcher(
         spec,
         modules,
+        ModulesResolutionMode.TOTAL,
         /* includeInstallTimeAssetModules= */ true,
         /* matchInstant= */ false,
         /* ensureDensityAndAbiApksMatched= */ true);
+  }
+
+  private static ApkMatcher createExactModulesMatcher(
+          DeviceSpec spec, Optional<ImmutableSet<String>> modules) {
+    return new ApkMatcher(
+            spec,
+            modules,
+            ModulesResolutionMode.EXACT,
+            /* includeInstallTimeAssetModules= */ true,
+            /* matchInstant= */ false,
+            /* ensureDensityAndAbiApksMatched= */ true);
   }
 }


### PR DESCRIPTION
# Context

There is a command in the [bundletool](https://developer.android.com/tools/bundletool) to measure the estimated download
sizes of APKs in an APK set as they would be served compressed over the wire:

```shell
java -jar bundletool.jar get-size total --apks=/MyApp/my_app.apks --modules=my_on_demand_module
```

The command by default includes all install-time modules in the estimation (see [`ApkMatcher#getRequestedModules`](../src/main/java/com/android/tools/build/bundletool/device/ApkMatcher.java)).
Additional on-demand modules can be included by specifying the `--modules` argument.

# Problem statement
While the `total` estimation is suitable for alerting systems to keep the app within [Google Play size limits](https://support.google.com/googleplay/android-developer/answer/9859372),
it may also be useful to estimate the app size that most users actually get. The command `get-size total` does not suit this
use case as it estimates the worst-case scenario, treating [conditional install-time](https://developer.android.com/guide/playcore/feature-delivery/conditional)
modules as install-time ones even though they are configured for a narrow audience (specific region, OS API level, etc.).

# Solution
To address this, `get-size` can be extended with the `exact` subcommand, which calculates the size only for the modules
explicitly specified via the `--modules` argument, keeping the `total` subcommand untouched.

```shell
java -jar bundletool.jar get-size exact --apks=/MyApp/my_app.apks --modules=base,widely_used_on_demand_module
```
